### PR TITLE
Fix #37 Flapi not working on MacOS (ports specifically)

### DIFF
--- a/flapi/__enable.py
+++ b/flapi/__enable.py
@@ -3,7 +3,6 @@
 
 Code for initializing/closing Flapi
 """
-
 import logging
 import random
 import mido  # type: ignore
@@ -25,13 +24,14 @@ from .errors import FlapiPortError, FlapiConnectionError, FlapiVersionError
 log = logging.getLogger(__name__)
 
 
-T = TypeVar("T", BaseInput, BaseOutput, covariant=True)
+T = TypeVar('T', BaseInput, BaseOutput, covariant=True)
 
 
 class OpenPortFn(Protocol, Generic[T]):
     """Function that opens a Mido port"""
 
-    def __call__(self, *, name: str, virtual: bool = False) -> T: ...
+    def __call__(self, *, name: str, virtual: bool = False) -> T:
+        ...
 
 
 def open_port(
@@ -46,14 +46,14 @@ def open_port(
     for curr_port_name in port_names:  # type: ignore
         # In mac, Audio MIDI Setup IAC ports always prepend "IAC Driver"
         # So manually created ports will always be named IAC Driver Flaip Request/Response
-        stripped_curr_port_name = curr_port_name.replace("IAC Driver", "")
+        stripped_curr_port_name = curr_port_name.replace('IAC Driver', '')
         if port_name.lower() not in stripped_curr_port_name.lower():
             continue
 
         # If the only thing after it is a number, we are free to connect to it
         # It seems that something appends these numbers to each MIDI device to
         # make them more unique or something
-        numeric_curr_port_name = stripped_curr_port_name.replace(port_name, "").strip()
+        numeric_curr_port_name = stripped_curr_port_name.replace(port_name, '').strip()
         if numeric_curr_port_name.isdigit():
             continue
 
@@ -131,8 +131,7 @@ def init(client_id: int):
     """
     if not try_init(client_id):
         raise FlapiConnectionError(
-            "FL Studio did not connect to Flapi - is it running?"
-        )
+            "FL Studio did not connect to Flapi - is it running?")
 
 
 def try_init(client_id: int) -> bool:

--- a/flapi/__enable.py
+++ b/flapi/__enable.py
@@ -3,6 +3,7 @@
 
 Code for initializing/closing Flapi
 """
+
 import logging
 import random
 import mido  # type: ignore
@@ -24,14 +25,13 @@ from .errors import FlapiPortError, FlapiConnectionError, FlapiVersionError
 log = logging.getLogger(__name__)
 
 
-T = TypeVar('T', BaseInput, BaseOutput, covariant=True)
+T = TypeVar("T", BaseInput, BaseOutput, covariant=True)
 
 
 class OpenPortFn(Protocol, Generic[T]):
     """Function that opens a Mido port"""
 
-    def __call__(self, *, name: str, virtual: bool = False) -> T:
-        ...
+    def __call__(self, *, name: str, virtual: bool = False) -> T: ...
 
 
 def open_port(
@@ -44,15 +44,17 @@ def open_port(
     attempt to create it
     """
     for curr_port_name in port_names:  # type: ignore
+        # In mac, Audio MIDI Setup IAC ports always prepend "IAC Driver"
+        # So manually created ports will always be named IAC Driver Flaip Request/Response
+        stripped_curr_port_name = curr_port_name.replace("IAC Driver", "")
+        if port_name.lower() not in stripped_curr_port_name.lower():
+            continue
+
         # If the only thing after it is a number, we are free to connect to it
         # It seems that something appends these numbers to each MIDI device to
         # make them more unique or something
-        if port_name.lower() not in curr_port_name.lower():
-            continue
-        try:
-            # If this works, it's a match
-            int(curr_port_name.replace(port_name, '').strip())
-        except Exception:
+        numeric_curr_port_name = stripped_curr_port_name.replace(port_name, "").strip()
+        if numeric_curr_port_name.isdigit():
             continue
 
         # Connect to it
@@ -101,11 +103,11 @@ def enable(
 
     if res is None or req is None:
         try:
-            req = mido.open_output(  # type: ignore
+            req = mido.open_ioport(  # type: ignore
                 name=req_port,
                 virtual=True,
             )
-            res = mido.open_input(  # type: ignore
+            res = mido.open_ioport(  # type: ignore
                 name=res_port,
                 virtual=True,
             )
@@ -129,7 +131,8 @@ def init(client_id: int):
     """
     if not try_init(client_id):
         raise FlapiConnectionError(
-            "FL Studio did not connect to Flapi - is it running?")
+            "FL Studio did not connect to Flapi - is it running?"
+        )
 
 
 def try_init(client_id: int) -> bool:


### PR DESCRIPTION
Addresses issue #37 

2-step fix here, although you only need 1 to get it working:

Fix 1: open_ioport for Auto Port Creation
Fix flapi creating ports itself on mac. We need to use the mido function open_ioport instead of open_input and open_output.

From here, the README instructions should work.

Fix 2: IAC Driver Port Name Matching for Manual Port Creation
For Audio MIDI Setup ports to work, we need to edit the open_port function slightly. The current code assumes that the drivers will be named exactly "Flapi XXX" with a number suffix. However, the mac driver created ports are always detected as "IAC Driver Flapi XXX". So this code will never find IAC Driver ports.

After doing this, I was able to connect to IAC ports, or have FLAPI create its own ports, and produce a healthy heartbeat.

<img width="1321" height="943" alt="image" src="https://github.com/user-attachments/assets/d9067881-8b94-476c-a680-fb720faec30b" />